### PR TITLE
Repro: first thread pagination stalls 3s waiting for a sync prev-batch token that never arrives

### DIFF
--- a/crates/matrix-sdk/tests/integration/event_cache/threads.rs
+++ b/crates/matrix-sdk/tests/integration/event_cache/threads.rs
@@ -60,6 +60,70 @@ async fn client_with_threading_support(server: &MatrixMockServer) -> Client {
 }
 
 #[async_test]
+async fn test_empty_thread_first_pagination_does_not_stall_waiting_for_sync_token() {
+    // Repro for the "first thread pagination stalls for 3s" issue.
+    //
+    // `ThreadEventCacheWrapper::wait_for_prev_token` blocks on
+    // `pagination_batch_token_notifier`, and the generic pagination gives that
+    // wait `DEFAULT_WAIT_FOR_TOKEN_DURATION` (3s). The notifier only fires
+    // when a sync stores a prev-batch gap for this specific thread — i.e.
+    // when a limited sync delivers *new* in-thread events. A thread with no
+    // replies (or whose replies aren't in the local cache yet, which is the
+    // common case when opening a thread for the first time) never receives
+    // one, so the first `run_backwards_once` sits out the full 3s before
+    // falling back to the `/relations` request. In a client whose thread view
+    // waits on that first pagination, every first thread open stalls ~3s.
+    let server = MatrixMockServer::new().await;
+    let client = client_with_threading_support(&server).await;
+
+    let room_id = room_id!("!galette:saucisse.bzh");
+
+    let event_cache = client.event_cache();
+    event_cache.subscribe().unwrap();
+
+    // The room is known, but no in-thread event has ever been received via
+    // sync, so the thread cache holds no prev-batch token and never will.
+    let _room = server.sync_room(&client, JoinedRoomBuilder::new(room_id)).await;
+
+    let thread_root_id = event_id!("$thread_root");
+    let (thread_event_cache, _drop_handles) =
+        event_cache.thread(room_id, thread_root_id).await.unwrap();
+
+    // The thread has no replies on the server either.
+    server
+        .mock_room_relations()
+        .match_target_event(thread_root_id.to_owned())
+        .ok(RoomRelationsResponseTemplate::default())
+        .mock_once()
+        .mount()
+        .await;
+
+    let f = EventFactory::new().room(room_id).sender(*ALICE);
+    server
+        .mock_room_event()
+        .match_event_id()
+        .ok(f.text_msg("Thread root").event_id(thread_root_id).into())
+        .mock_once()
+        .mount()
+        .await;
+
+    let start = std::time::Instant::now();
+    let outcome = thread_event_cache.pagination().run_backwards_once(42).await.unwrap();
+    let elapsed = start.elapsed();
+
+    assert!(outcome.reached_start);
+
+    // Both mocked endpoints answer in milliseconds, so the pagination should
+    // complete quickly. On current main this fails at ~3.02s: the whole
+    // DEFAULT_WAIT_FOR_TOKEN_DURATION is spent waiting for a token that can
+    // never arrive.
+    assert!(
+        elapsed < Duration::from_secs(2),
+        "empty-thread first pagination stalled waiting for a sync token: {elapsed:?}"
+    );
+}
+
+#[async_test]
 async fn test_thread_contains_its_root_event() {
     let server = MatrixMockServer::new().await;
     let client = client_with_threading_support(&server).await;


### PR DESCRIPTION
**Staging artifact for an upstream matrix-org/matrix-rust-sdk issue — not meant to merge.** The diff is a failing integration test demonstrating the stall on current upstream `main`. The text below is ready to copy into the upstream issue.

---

## Summary

The first back-pagination of a `ThreadEventCache` that holds no prev-batch token blocks for the full `DEFAULT_WAIT_FOR_TOKEN_DURATION` (3 s) before falling back to the `/relations` request. For threads, the token it waits for can only arrive if a limited sync delivers **new in-thread events for that specific thread** during the wait — so in the common cases (a thread with no replies, or a thread whose replies aren't in the local cache yet, i.e. any thread opened for the first time on a device) the timeout is always fully consumed. A client whose thread view waits on the first pagination stalls ~3 s on every first thread open.

## Mechanism

- `Pagination::paginate_backwards_impl` (`event_cache/caches/pagination.rs`): when `load_more_events_backwards` returns `Gap { prev_token: None }` and we haven't waited yet, it waits on `cache.wait_for_prev_token()` bounded by `DEFAULT_WAIT_FOR_TOKEN_DURATION = 3s`.
- For threads, `ThreadEventCacheWrapper::wait_for_prev_token` (`event_cache/caches/thread/pagination.rs`) blocks on `pagination_batch_token_notifier`, introduced with thread persistent storage in #6317 ("Insert gaps in threads"; previously a no-op stub: `// TODO: implement once we have persistent storage`).
- That notifier fires only from `ThreadEventCache::handle_timeline` → `handle_sync`, when the per-thread `Timeline` synthesized by the sync aggregation carries a `prev_batch` and non-duplicate events — i.e. a limited sync containing **new replies to this exact thread**.
- Consequently:
  - Thread with no replies → token never arrives → full 3 s wait, then `/relations` returns empty and the root is fetched.
  - Thread whose replies were previously delivered by a *gappy* sync → a gap token is already stored → the wait never runs (fine).
  - Thread whose replies were delivered contiguously, or not delivered at all (history predates the device's sync window — the typical "open an old thread" case) → no token exists and none will ever be stored for the past → full 3 s wait, then `/relations`.

The same wait is effectively free for the *room* cache, because a room's first sync almost always delivers a `prev_batch` within milliseconds and the notifier short-circuits the wait. For threads the cost profile is inverted: the expected case is "token never comes", so the timeout is paid in full, once per thread (per `waited_for_initial_prev_token`).

## Repro

`test_empty_thread_first_pagination_does_not_stall_waiting_for_sync_token` (this PR's diff) mocks a room with no synced thread events, an empty `/relations` response, and the root-event fetch, then runs one `run_backwards_once` on the thread cache. Both endpoints answer in milliseconds; the pagination should complete quickly. On current `main` it fails with:

```
empty-thread first pagination stalled waiting for a sync token: 3.009358393s
```

Run with:

```
cargo test -p matrix-sdk --test integration --features testing,e2e-encryption \
  event_cache::threads::test_empty_thread_first_pagination
```

## Impact

Element X is partially shielded because its thread view renders from the cache subscription and shows the stall only as the top pagination indicator; clients that gate the thread view on the first pagination stall visibly for 3 s+ on every first thread open. Filament measured 4.7–5.9 s click→content for empty threads on a localhost homeserver, dropping to ~2.5 s with the wait bounded.

## Possible fixes

- Skip the wait when the thread's linked chunk is empty and fully loaded from the store (no token can be pending from disk; only a future sync could produce one).
- Or make the wait conditional on a sync response for the room currently being processed.
- Or bound the thread-side wait much lower (we're running 250 ms vendored: the notifier still short-circuits when a token is genuinely in flight, and `filter_duplicate_events` + the misordering guard in `conclude_backwards_pagination_from_network` already reconcile any overlap between the `/relations` fallback and a concurrent sync).